### PR TITLE
Release 1.1.0: zero runtime dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+  workflow_dispatch:
+
+jobs:
+  publish:
+    # Requires automated publishing to be enabled for this repository on
+    # pub.dev (package Admin tab) with tag pattern v{{version}}.
+    permissions:
+      id-token: write # OIDC authentication with pub.dev
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Analyze
+        run: flutter analyze
+      - name: Run tests
+        run: flutter test
+      - name: Publish
+        run: flutter pub publish --force

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,32 @@
+name: Tag release on main
+
+on:
+  push:
+    branches: [main]
+    paths: [pubspec.yaml]
+
+jobs:
+  tag:
+    permissions:
+      contents: write # push the version tag
+      actions: write # dispatch the publish workflow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create tag for new version and trigger publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(grep '^version:' pubspec.yaml | sed 's/version:[[:space:]]*//')
+          TAG="v$VERSION"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $VERSION"
+          git push origin "$TAG"
+          # Tags pushed with GITHUB_TOKEN don't fire push-triggered workflows
+          # (anti-recursion), so dispatch the publish workflow explicitly.
+          gh workflow run publish.yml --ref "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+
+- **Changed**: the plugin now has **zero runtime dependencies** — `equatable` and `plugin_platform_interface` were removed.
+- `Ringtone` implements `==`/`hashCode` directly; equality semantics are unchanged (all three fields).
+- `FlutterSystemRingtonesPlatform` is now a plain abstract class with a settable `instance`. If you implemented it in tests, drop the `MockPlatformInterfaceMixin` mixin — just `implements` the class.
+
 ## 1.0.0
 
 - **Added**: `play(Ringtone)` and `stop()` for previewing sounds natively (Android `RingtoneManager`, iOS `AVAudioPlayer`). `play` auto-stops the previously playing sound.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -177,14 +177,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.6"
-  plugin_platform_interface:
-    dependency: transitive
-    description:
-      name: plugin_platform_interface
-      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.8"
   process:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,14 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
-  equatable:
-    dependency: transitive
-    description:
-      name: equatable
-      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:

--- a/ios/flutter_system_ringtones.podspec
+++ b/ios/flutter_system_ringtones.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_system_ringtones'
-  s.version          = '1.0.0'
+  s.version          = '1.1.0'
   s.summary          = 'Flutter plugin to list and preview system ringtones, alarms and notification sounds.'
   s.description      = <<-DESC
 A Flutter plugin that lists the device's system ringtones, alarms and

--- a/lib/flutter_system_ringtones_platform_interface.dart
+++ b/lib/flutter_system_ringtones_platform_interface.dart
@@ -5,19 +5,12 @@ import 'flutter_system_ringtones_method_channel.dart';
 /// The interface that platform-specific implementations of
 /// flutter_system_ringtones must implement.
 abstract class FlutterSystemRingtonesPlatform {
-  static FlutterSystemRingtonesPlatform _instance =
-      MethodChannelFlutterSystemRingtones();
-
-  /// The default instance of [FlutterSystemRingtonesPlatform] to use.
+  /// The instance of [FlutterSystemRingtonesPlatform] to use.
   ///
-  /// Defaults to [MethodChannelFlutterSystemRingtones].
-  static FlutterSystemRingtonesPlatform get instance => _instance;
-
-  /// Platform-specific implementations (or tests) can replace the default
-  /// method-channel implementation by setting this.
-  static set instance(FlutterSystemRingtonesPlatform instance) {
-    _instance = instance;
-  }
+  /// Defaults to [MethodChannelFlutterSystemRingtones]. Platform-specific
+  /// implementations (or tests) can replace it by setting this.
+  static FlutterSystemRingtonesPlatform instance =
+      MethodChannelFlutterSystemRingtones();
 
   Future<List<Ringtone>?> getRingtones() {
     throw UnimplementedError('getRingtones() has not been implemented.');

--- a/lib/flutter_system_ringtones_platform_interface.dart
+++ b/lib/flutter_system_ringtones_platform_interface.dart
@@ -1,26 +1,21 @@
 import 'package:flutter_system_ringtones/src/ringtone.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'flutter_system_ringtones_method_channel.dart';
 
-abstract class FlutterSystemRingtonesPlatform extends PlatformInterface {
-  /// Constructs a FlutterSystemRingtonesPlatform.
-  FlutterSystemRingtonesPlatform() : super(token: _token);
-
-  static final Object _token = Object();
-
-  static FlutterSystemRingtonesPlatform _instance = MethodChannelFlutterSystemRingtones();
+/// The interface that platform-specific implementations of
+/// flutter_system_ringtones must implement.
+abstract class FlutterSystemRingtonesPlatform {
+  static FlutterSystemRingtonesPlatform _instance =
+      MethodChannelFlutterSystemRingtones();
 
   /// The default instance of [FlutterSystemRingtonesPlatform] to use.
   ///
   /// Defaults to [MethodChannelFlutterSystemRingtones].
   static FlutterSystemRingtonesPlatform get instance => _instance;
 
-  /// Platform-specific implementations should set this with their own
-  /// platform-specific class that extends [FlutterSystemRingtonesPlatform] when
-  /// they register themselves.
+  /// Platform-specific implementations (or tests) can replace the default
+  /// method-channel implementation by setting this.
   static set instance(FlutterSystemRingtonesPlatform instance) {
-    PlatformInterface.verifyToken(instance, _token);
     _instance = instance;
   }
 

--- a/lib/src/ringtone.dart
+++ b/lib/src/ringtone.dart
@@ -1,55 +1,56 @@
 import 'dart:convert';
 
-import 'package:equatable/equatable.dart';
-
-class Ringtone extends Equatable {
+class Ringtone {
   final String id;
   final String title;
-  // final Uint8List data;
   final String uri;
 
   const Ringtone({
     required this.id,
     required this.title,
-    // required this.data,
     required this.uri,
   });
 
   factory Ringtone.fromJson(Map<String, dynamic> map) => Ringtone(
         id: map['id'] as String,
         title: map['title'] as String,
-        // data: Uint8List.fromList(map['data']),
         uri: map['uri'] as String,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
-        // 'data': data,
         'uri': uri,
       };
 
   factory Ringtone.fromEncodedJson(String encodedJson) =>
       Ringtone.fromJson(json.decode(encodedJson));
   String toEncodedJson() => json.encode(toJson());
+
   @override
   String toString() {
     return 'Ringtone{id: $id, title: $title, uri: $uri}';
   }
 
   @override
-  List<Object?> get props => [id, title, uri];
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Ringtone &&
+          other.id == id &&
+          other.title == title &&
+          other.uri == uri;
+
+  @override
+  int get hashCode => Object.hash(id, title, uri);
 
   Ringtone copyWith({
     String? id,
     String? title,
-    // Uint8List? data,
     String? uri,
   }) {
     return Ringtone(
       id: id ?? this.id,
       title: title ?? this.title,
-      // data: data ?? this.data,
       uri: uri ?? this.uri,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  plugin_platform_interface: ^2.0.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
   flutter: ">=3.24.0"
 
 dependencies:
-  equatable: ^2.0.5
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_system_ringtones
 description: A Flutter plugin to list and preview system ringtones, alarms and notification sounds on Android and iOS.
-version: 1.0.0
+version: 1.1.0
 homepage: https://pub.dev/packages/flutter_system_ringtones
 repository: https://github.com/imedboumalek/flutter_system_ringtones
 

--- a/test/flutter_system_ringtones_test.dart
+++ b/test/flutter_system_ringtones_test.dart
@@ -2,10 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_system_ringtones/flutter_system_ringtones.dart';
 import 'package:flutter_system_ringtones/flutter_system_ringtones_platform_interface.dart';
 import 'package:flutter_system_ringtones/flutter_system_ringtones_method_channel.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 class MockFlutterSystemRingtonesPlatform
-    with MockPlatformInterfaceMixin
     implements FlutterSystemRingtonesPlatform {
 
   final List<String> log = [];

--- a/test/ringtone_test.dart
+++ b/test/ringtone_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_system_ringtones/flutter_system_ringtones.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const ringtone = Ringtone(id: '1', title: 'Chime', uri: 'uri1');
+
+  test('instances with the same fields are equal', () {
+    expect(ringtone, const Ringtone(id: '1', title: 'Chime', uri: 'uri1'));
+    expect(
+      ringtone.hashCode,
+      const Ringtone(id: '1', title: 'Chime', uri: 'uri1').hashCode,
+    );
+  });
+
+  test('instances differing in any field are not equal', () {
+    expect(ringtone, isNot(ringtone.copyWith(id: '2')));
+    expect(ringtone, isNot(ringtone.copyWith(title: 'Bell')));
+    expect(ringtone, isNot(ringtone.copyWith(uri: 'uri2')));
+  });
+
+  test('copyWith without arguments returns an equal instance', () {
+    expect(ringtone.copyWith(), ringtone);
+  });
+
+  test('json round-trips', () {
+    expect(Ringtone.fromJson(ringtone.toJson()), ringtone);
+    expect(Ringtone.fromEncodedJson(ringtone.toEncodedJson()), ringtone);
+  });
+}


### PR DESCRIPTION
## Summary

Makes the plugin fully self-contained, as teased in the 1.0.0 announcement:

- Removed `equatable` — `Ringtone` implements `==`/`hashCode` directly, same semantics (all three fields), now locked in by dedicated model tests (equality, `copyWith`, JSON round-trips).
- Removed `plugin_platform_interface` — `FlutterSystemRingtonesPlatform` is a plain abstract class with a settable `instance`. The token-verification machinery only benefits federated plugins with third-party platform packages, which this isn't. Anyone faking the platform in tests just drops `MockPlatformInterfaceMixin`.
- The dependencies section of the pubspec is now just the Flutter SDK.

## Test plan

- `flutter analyze` clean (plugin + example)
- `flutter test`: 16 tests passing (4 new `Ringtone` model tests)
- Integration tests re-run on a physical Android device: 4/4 passing
- `flutter pub publish --dry-run`: 0 warnings