### PR TITLE
Release 1.1.1: pub.dev topics and GitHub links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Package metadata: added pub.dev topics; homepage and issue tracker now point at the GitHub repository.
+
 ## 1.1.0
 
 - **Changed**: the plugin now has **zero runtime dependencies** — `equatable` and `plugin_platform_interface` were removed.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -89,7 +89,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.1.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/ios/flutter_system_ringtones.podspec
+++ b/ios/flutter_system_ringtones.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_system_ringtones'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'Flutter plugin to list and preview system ringtones, alarms and notification sounds.'
   s.description      = <<-DESC
 A Flutter plugin that lists the device's system ringtones, alarms and

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,16 @@
 name: flutter_system_ringtones
 description: A Flutter plugin to list and preview system ringtones, alarms and notification sounds on Android and iOS.
-version: 1.1.0
-homepage: https://pub.dev/packages/flutter_system_ringtones
+version: 1.1.1
+homepage: https://github.com/imedboumalek/flutter_system_ringtones
 repository: https://github.com/imedboumalek/flutter_system_ringtones
+issue_tracker: https://github.com/imedboumalek/flutter_system_ringtones/issues
+
+topics:
+  - audio
+  - sound
+  - ringtones
+  - alarms
+  - notifications
 
 environment:
   sdk: ^3.4.0


### PR DESCRIPTION
Metadata-only release:

- Adds pub.dev topics: audio, sound, ringtones, alarms, notifications
- Homepage and new issue_tracker field now point at the GitHub repository (homepage previously pointed circularly at the pub.dev page)
- `flutter pub publish --dry-run`: clean apart from the uncommitted-state warning at check time

Merging this will auto-tag v1.1.1 and publish via the CI pipeline.